### PR TITLE
fix: Modify healthcheck script to monitor spamd instead of spamassassin service

### DIFF
--- a/scripts/status.sh
+++ b/scripts/status.sh
@@ -8,11 +8,11 @@ if [[ $DETAILED_LOGGING == "true" ]]; then
     >&2 echo "HELTHCHECK: DETAILED_LOGGING"
 fi
 
-service spamassassin status > /dev/null
+service spamd status > /dev/null
 
 if [[ $? -eq 1 ]]; then
   if [[ $DETAILED_LOGGING == "true" ]]; then
-    >&2 echo "HELTHCHECK: spamassassin stopped"
+    >&2 echo "HELTHCHECK: spamd stopped"
   fi
   exit 1
 fi


### PR DESCRIPTION
Hi,
I was doing some tests with this image yesterday, the mail filtering mails was working fine but the container was returning an unhealthy status. Turns out the /root/status.sh script was checking on spamassassin service which is no longer used since 1.0.0. 

 I've updated the script to check on spamd service and now the container is returning a healthy status.