### PR TITLE
Prevent deleting whole Inbox

### DIFF
--- a/accounts/sombody@somewhere.com.conf.example
+++ b/accounts/sombody@somewhere.com.conf.example
@@ -7,7 +7,8 @@
 	"spamSubject": "[SPAM?]",
 	"report": "yes",
 	"spamLifetime": 30,
-	"mailLifetime": 30,
+	// IMPORTANT: Using mailLifetime will empty your WHOLE INBOX! Only use, if you really want to!
+	// "mailLifetime": 30,
 	"folders": {
         "inbox": "INBOX",
 		"spam": "Spam",


### PR DESCRIPTION
Unfortunately, my whole Inbox got lost during the first run of this program.
Just because I didn't read the conf file exactly and misunderstood the lifetime argument just for spam, not for the whole inbox. That's now really pity and I hope, I can get it back with an extra paid backup.

This is just to prevent anybody else from this.